### PR TITLE
Fix warning from chown

### DIFF
--- a/buildslackpkg.sh
+++ b/buildslackpkg.sh
@@ -6,7 +6,7 @@ PKGNAME=cpan2tgz
 
 perl Makefile.PL
 make
-chown -R root.root .
+chown -R root:root .
 find . -perm 777 -exec chmod 755 {} \;
 find . -perm 555 -exec chmod 755 {} \;
 find . -perm 444 -exec chmod 644 {} \;

--- a/cpan2tgz
+++ b/cpan2tgz
@@ -227,7 +227,7 @@ sub do_package
   # this isn't pretty but it gets the job done
   my $pack_dir = $pack->dir();
 
-  system("cd $pack_dir && chown -R root.root .");
+  system("cd $pack_dir && chown -R root:root .");
   system("cd $pack_dir && find . -perm 777 -exec chmod 755 {} \\;");
   system("cd $pack_dir && find . -perm 555 -exec chmod 755 {} \\;");
   system("cd $pack_dir && find . -perm 444 -exec chmod 644 {} \\;");


### PR DESCRIPTION
`chown` issues a warning when using `USER.GROUP` format:

```
chown: warning: '.' should be ':': 'root.root'
```

Use `USER:GROUP` format instead.