### PR TITLE
Minor slack-desc improvements

### DIFF
--- a/buildslackpkg.sh
+++ b/buildslackpkg.sh
@@ -63,15 +63,15 @@ EOF
 
           |-----handy-ruler------------------------------------------------------|
 ${PKGNAME}: ${PKGNAME} - create Slackware packages from CPAN Perl modules
-${PKGNAME}: 
+${PKGNAME}:
 ${PKGNAME}: Packaged by cpan2tgz
-${PKGNAME}: 
+${PKGNAME}:
 ${PKGNAME}: cpan2tgz by Jason Woodward <woodwardj at jaos dot org>
-${PKGNAME}: 
-${PKGNAME}: 
-${PKGNAME}: 
-${PKGNAME}: http://software.jaos.org/
-${PKGNAME}: 
+${PKGNAME}:
+${PKGNAME}:
+${PKGNAME}:
+${PKGNAME}: https://software.jaos.org/
+${PKGNAME}:
 EOF
 	makepkg -l y -c n ../${PKGNAME}-${VERSION}-noarch-1.txz
 )

--- a/buildslackpkg.sh
+++ b/buildslackpkg.sh
@@ -70,6 +70,7 @@ ${PKGNAME}: cpan2tgz by Jason Woodward <woodwardj at jaos dot org>
 ${PKGNAME}:
 ${PKGNAME}:
 ${PKGNAME}:
+${PKGNAME}:
 ${PKGNAME}: https://software.jaos.org/
 ${PKGNAME}:
 EOF

--- a/cpan2tgz
+++ b/cpan2tgz
@@ -310,7 +310,7 @@ SCRIPT
   print $desc_fh "$final_pkg_name:  \n";
   print $desc_fh "$final_pkg_name:  Packaged by cpan2tgz\n" unless $nobanner;
   print $desc_fh "$final_pkg_name:  cpan2tgz by Jason Woodward <woodwardj\@jaos.org>\n" unless $nobanner;
-  print $desc_fh "$final_pkg_name:  http://software.jaos.org/\n" unless $nobanner;
+  print $desc_fh "$final_pkg_name:  https://software.jaos.org/\n" unless $nobanner;
   print $desc_fh "$final_pkg_name:  \n";
   close($desc_fh);
 

--- a/cpan2tgz
+++ b/cpan2tgz
@@ -302,16 +302,16 @@ SCRIPT
   print $desc_fh "\n";
   print $desc_fh "         |-----handy-ruler------------------------------------------------------|\n";
   print $desc_fh "$final_pkg_name: $final_pkg_name " . $module->cpan_version() . " (Perl module)\n";
-  print $desc_fh "$final_pkg_name:  \n";
-  print $desc_fh "$final_pkg_name:  \n";
-  print $desc_fh "$final_pkg_name:  \n";
-  print $desc_fh "$final_pkg_name:  \n";
-  print $desc_fh "$final_pkg_name:  \n";
-  print $desc_fh "$final_pkg_name:  \n";
+  print $desc_fh "$final_pkg_name:\n";
+  print $desc_fh "$final_pkg_name:\n";
+  print $desc_fh "$final_pkg_name:\n";
+  print $desc_fh "$final_pkg_name:\n";
+  print $desc_fh "$final_pkg_name:\n";
+  print $desc_fh "$final_pkg_name:\n";
   print $desc_fh "$final_pkg_name:  Packaged by cpan2tgz\n" unless $nobanner;
   print $desc_fh "$final_pkg_name:  cpan2tgz by Jason Woodward <woodwardj\@jaos.org>\n" unless $nobanner;
   print $desc_fh "$final_pkg_name:  https://software.jaos.org/\n" unless $nobanner;
-  print $desc_fh "$final_pkg_name:  \n";
+  print $desc_fh "$final_pkg_name:\n";
   close($desc_fh);
 
   # finally, build the package


### PR DESCRIPTION
- Omit trailing whitespace
- Ensure slack-desc for cpan2tgz itself gets an 11th line
- Update http://software.jaos.org to use the HTTPS URL