### PR TITLE
Fix misnamed packages

### DIFF
--- a/cpan2tgz
+++ b/cpan2tgz
@@ -118,7 +118,7 @@ sub do_package
   my $pkg_name = "perl-" . lc((split('/',$module->cpan_file))[-1]);
   my $final_pkg_version = (split('-',$pkg_name))[-1];
   (my $final_pkg_name = $pkg_name) =~ s/\-$final_pkg_version//;
-  $pkg_name =~ s/\.tar.*?$//;
+  $pkg_name =~ s/\.(?:tar.*?|tgz|zip)$//;
 
   # figure out the arch of the package, default to noarch
   my @xs_files = ();


### PR DESCRIPTION
When the CPAN dist file ends with `.zip`, or anything other than `.tar.*`, the package name generated would include the suffix.

For example:
- [`MP3::Tag`](https://metacpan.org/pod/MP3::Tag) -> [`MP3-Tag-1.16.zip`](https://cpan.metacpan.org/authors/id/I/IL/ILYAZ/modules/MP3-Tag-1.16.zip) -> `perl-mp3-tag-1.16.zip-noarch-1h3x.txz`
- [`Config::Tiny`](https://metacpan.org/pod/Config::Tiny) -> [`Config-Tiny-2.29.tgz`](https://cpan.metacpan.org/authors/id/R/RS/RSAVAGE/Config-Tiny-2.29.tgz) -> `perl-config-tiny-2.29.tgz-noarch-1h3x.txz`

This strips `.zip`, and `.tgz` from the package names, as well as the most common `.tar.*`.

Further research would be needed to determine if there are other formats in the CPAN collection.