### PR TITLE
Fix warning re: uninitialized variable used in m//

### DIFF
--- a/cpan2tgz
+++ b/cpan2tgz
@@ -174,8 +174,8 @@ sub do_package
     my $deps = $pack->prereq_pm();
 
     # only get the deps that are not installed
-    @deps = grep { defined && m/\w+/; }
-      grep { ! m/^perl$/ }
+    @deps = grep { ! m/^perl$/ }
+      grep { defined && m/\w+/; }
       map { defined $PACKAGE_CACHE_LIST{$_} ? undef : $_ }
       map { m/requires$/ ? keys %{$deps->{$_}} : $_ }
       keys %{$deps};


### PR DESCRIPTION
Reverse order of 'grep' filters.